### PR TITLE
fix: replace useEffect with useSyncExternalStore

### DIFF
--- a/packages/core/src/useCounter/index.ts
+++ b/packages/core/src/useCounter/index.ts
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useState,
+  useMemo,
   type SetStateAction,
   type Dispatch,
 } from "react";
@@ -40,11 +41,16 @@ export function useCounter(initialValue?: number): CounterReturnType {
     setCount(initialValue ?? 0);
   }, [initialValue]);
 
-  return {
-    increment,
-    decrement,
-    reset,
-    count,
-    setCount,
-  };
+  const returnObject = useMemo(
+    () => ({
+      increment,
+      decrement,
+      reset,
+      count,
+      setCount,
+    }),
+    [increment, decrement, reset, count, setCount],
+  );
+
+  return returnObject;
 }

--- a/packages/core/src/useDevice/index.ts
+++ b/packages/core/src/useDevice/index.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 
 type DeviceDetect = {
   isMobile: boolean;
@@ -12,26 +12,17 @@ type DeviceDetect = {
 const description =
   "A hook that detects the device type and returns a boolean value for each device type.";
 
-/**
- * A hook that detects the device type and returns a boolean value for each device type.
- *
- * @returns {DeviceDetect} - An object containing boolean values for each device type.
- */
-export function useDevice(): DeviceDetect {
-  const [deviceType, setDeviceType] = useState<string | null>(null);
+// Device type is constant and never changes
+const emptySubscribe = () => () => {};
 
-  useEffect(() => {
-    const userAgent = navigator.userAgent;
-
-    if (/tablet/i.test(userAgent)) {
-      setDeviceType("tablet");
-    } else if (/mobile/i.test(userAgent)) {
-      setDeviceType("mobile");
-    } else {
-      setDeviceType("desktop");
-    }
-  }, []);
-
+const getDeviceTypeClient = (): DeviceDetect => {
+  const userAgent = navigator.userAgent;
+  let deviceType = "desktop";
+  if (/tablet/i.test(userAgent)) {
+    deviceType = "tablet";
+  } else if (/mobile/i.test(userAgent)) {
+    deviceType = "mobile";
+  }
   const isMobile = deviceType === "mobile";
   const isDesktop = deviceType === "desktop";
   const isTablet = deviceType === "tablet";
@@ -48,4 +39,26 @@ export function useDevice(): DeviceDetect {
     MobileView,
     TabletView,
   };
+};
+
+const getDeviceTypeServer = (): DeviceDetect => ({
+  isMobile: false,
+  isDesktop: true,
+  isTablet: false,
+  DesktopView: () => true,
+  MobileView: () => false,
+  TabletView: () => false,
+});
+
+/**
+ * A hook that detects the device type and returns a boolean value for each device type.
+ *
+ * @returns {DeviceDetect} - An object containing boolean values for each device type.
+ */
+export function useDevice(): DeviceDetect {
+  return useSyncExternalStore(
+    emptySubscribe,
+    getDeviceTypeClient,
+    getDeviceTypeServer,
+  );
 }


### PR DESCRIPTION
The react team recommends using `useSyncExternalStore` instead of `useEffect` - https://react.dev/learn/you-might-not-need-an-effect#subscribing-to-an-external-store

Also I saw that in `useCounter` you don't wrap the final object in `useMemo`. This means react will create a new object each render causing additional rerenders.