### PR TITLE
feat: support JSONC configs (tsconfig.json and rehooks.json)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@clack/prompts": "^0.9.0",
+    "@rehooks/eslint-config": "workspace:*",
     "@types/node": "22.5.4",
     "@types/semver": "^7.5.8",
     "colorette": "^2.0.20",
@@ -52,13 +53,13 @@
     "tsup": "^8.3.0",
     "type-fest": "^4.26.1",
     "typescript": "^5.6.3",
-    "zod": "^3.23.8",
-    "@rehooks/eslint-config": "workspace:*"
+    "zod": "^3.23.8"
   },
   "dependencies": {
     "axios": "^1.7.7",
     "commander": "^12.1.0",
     "cosmiconfig": "^9.0.0",
+    "jsonc-parser": "^3.3.1",
     "ora": "^8.1.0",
     "package-json": "^10.0.1",
     "semver": "^7.6.3"

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -1,5 +1,6 @@
 import { log } from "@clack/prompts";
 import { cosmiconfig } from "cosmiconfig";
+import * as jsonc from "jsonc-parser";
 
 import { handleError } from "./error";
 import type { RehooksConfig } from "~/schema/config.schema";
@@ -7,12 +8,31 @@ import { configSchema } from "~/schema/config.schema";
 import type { TsConfig } from "~/schema/tsconfig.schema";
 import { tsConfigSchema } from "~/schema/tsconfig.schema";
 
+function jsonLoader(filepath: string, content: string) {
+  const errors: jsonc.ParseError[] = [];
+  const result = jsonc.parse(content, errors, {
+    allowTrailingComma: true,
+  });
+
+  if (errors.length > 0) {
+    throw new Error(`Error parsing JSON: ${JSON.stringify(errors)}`);
+  }
+
+  return result;
+}
+
 const configExplorer = cosmiconfig("rehooks", {
   searchPlaces: ["rehooks.json"],
+  loaders: {
+    ".json": jsonLoader,
+  },
 });
 
 const tsConfigExplorer = cosmiconfig("tsconfig", {
   searchPlaces: ["tsconfig.json"],
+  loaders: {
+    ".json": jsonLoader,
+  },
 });
 
 export async function getConfig(cwd: string): Promise<RehooksConfig | null> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       cosmiconfig:
         specifier: ^9.0.0
         version: 9.0.0(typescript@5.6.3)
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       ora:
         specifier: ^8.1.0
         version: 8.1.0
@@ -3102,6 +3105,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   jsonpointer@5.0.1:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
@@ -7844,6 +7850,8 @@ snapshots:
       minimist: 1.2.8
 
   json5@2.2.3: {}
+
+  jsonc-parser@3.3.1: {}
 
   jsonpointer@5.0.1: {}
 


### PR DESCRIPTION
Got this error caused by `// comments` in my `tsconfig.json` file (since tsconfig.json support JSONC).

Here is the fix

```
npx rehooks-cli@latest init

┌  Initializing Rehooks...
│
▲  Rehooks configuration already exists.
│
◇  Rehooks configuration already exists. Do you want to overwrite it?
│  Yes
│
●  Previous hooks directory at ./src/hooks has been removed.
│
◇  Does your project have a src folder?
│  Yes
│
●  Creating rehooks.json configuration file...
│
◆  Rehooks configuration file created at /Users/xxx/dev/xxxx/rehooks.json.
│
◆  Configuration loaded successfully.
│
■  Error loading TypeScript configuration from /Users/xxxx/dev/xxxxx/tsconfig.json: JSONError: JSON Error in /Users/xxxx/dev/xxxxxx/tsconfig.json:
│  Unexpected non-whitespace character after JSON at position 20 (line 2 column 20) while parsing '  "compilerOptions": {    /* Base Opti'
│
■  Error loading TypeScript configuration from /Users/xxxx/dev/xxxxxx/tsconfig.json: JSONError: JSON Error in /Users/xxxxx/dev/xxxxxxxx/tsconfig.json:
│  Unexpected non-whitespace character after JSON at position 20 (line 2 column 20) while parsing '  "compilerOptions": {    /* Base Opti'

```